### PR TITLE
make update-template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,5 +74,7 @@ update-template:
 
 update-template-old: update-template
 	$(SED) -i 's/[0-9]\+pt, *\(% *8-20pt *possible.*\)\?/a4paper,/' main.tex || true
+	$(SED) -i 's/\\begin{tabular}/\\centerline{\\begin{tabular}/' main.tex || true
+	$(SED) -i 's/\\end{tabular}/\\end{tabular}}/' main.tex || true
 	git add Makefile latexmkrc templates
 	test -f art.cls && git rm -f art.cls || true

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ ORG := $(shell git ls-files | grep '\.org$$')
 MD_TEX := $(patsubst %.md,%.md.tex,$(MD))
 ORG_TEX := $(patsubst %.org,%.org.tex,$(ORG))
 
+SED ?= $(shell which gsed 2>/dev/null || which sed)
+TAR ?= $(shell which gtar 2>/dev/null || which tar)
+
 OUT ?= output
 
 LATEXMK ?= latexmk
@@ -65,3 +68,11 @@ clean-latex:
 	rm -f $(OUT)/main.{blg,bbl,brf,aux,out,fls,xdv,toc,log,fdb_latexmk}
 
 clean: clean-pandoc clean-latex
+
+update-template:
+	curl -sL https://github.com/anoma/art-template/tarball/main | gunzip -c | $(TAR) xv --strip-components=1 --wildcards '*/Makefile' '*/latexmkrc' '*/templates'
+
+update-template-old: update-template
+	$(SED) -i 's/[0-9]\+pt, *\(% *8-20pt *possible.*\)\?/a4paper,/' main.tex || true
+	git add Makefile latexmkrc templates
+	test -f art.cls && git rm -f art.cls || true

--- a/templates/ART/art.cls
+++ b/templates/ART/art.cls
@@ -351,7 +351,7 @@ fit,                         % TIKZ fitting
 \newcolumntype{P}[1]{>{\centering\arraybackslash}p{#1}}
 
 \AtBeginEnvironment{tabular}{%                % font inside tables will be small
-  \fontsize{10}{12}\selectfont
+  \fontsize{9}{11}\selectfont
 }
 %% command we can use to add some text e.g. below the table
 \newcommand{\addtabletext}[1]{{\setlength{\leftskip}{9pt}\fontsize{7}{9}\selectfont#1}}


### PR DESCRIPTION
`make update-template`

Download the latest snapshot of the main branch and extract the following from the archive:
- `Makefile`
- `latexmkrc`
- `templates/`

When updating from the old template, additional steps required:
- `wget https://raw.githubusercontent.com/anoma/art-template/main/Makefile`
- `make update-template-old`

This will:
- download Makefile
- add `a4paper` and remove font size class options in `main.tex`
- `git rm art.cls` and `git add` new template