### PR TITLE
feat: add threeparttable and example

### DIFF
--- a/examples/test.tex
+++ b/examples/test.tex
@@ -208,20 +208,23 @@ A solution to the graph coloring problem is then an assignment of colors that sa
 
 \begin{table*}[!h]
 \begin{center}
-\begin{tabular}{|p{1.5cm}|p{13cm}|}
-\hline
- \textbf{Role} & \textbf{Description} \\ \hline
- Authorizer & approves the resource consumption on the application level. The resource logic encodes the mechanism that connects the authorizer's external identity (public key) to the decision-making process \\ \hline
- Annuler & knows the data required to nullify a resource
- \\ \hline
-Creator & creates the resource and shares the data with the receiver
-\\ \hline
-Owner & can both authorize and annul a resource
-\\ \hline
-Sender & owns the resources that were consumed to create the created resource
-\\ \hline
-Receiver & owns the created resource
-\\ \hline
+\begin{tabular}{p{1.5cm}p{13cm}}
+\toprule
+  \textbf{Role} & \textbf{Description} \\
+\midrule
+  Authorizer & approves the resource consumption on the application level. The resource logic encodes the mechanism that connects the authorizer's external identity (public key) to the decision-making process 
+  \\
+  Annuler & knows the data required to nullify a resource
+  \\
+  Creator & creates the resource and shares the data with the receiver
+  \\
+  Owner & can both authorize and annul a resource
+  \\
+  Sender & owns the resources that were consumed to create the created resource
+  \\
+  Receiver & owns the created resource
+  \\
+\bottomrule
 \end{tabular}
 \caption{Resource-related roles.}
 \end{center}

--- a/templates/ART/art.cls
+++ b/templates/ART/art.cls
@@ -371,6 +371,7 @@ fit,                         % TIKZ fitting
 
 % Tables
 \RequirePackage{
+  threeparttable,                             % clean separators (with '\toprule', '\midrule', '\bottomrule')
   booktabs,                                   % overall nice table quality
   array,                                      % better column and row definitions
   longtable,                                  % for tables spanning multiple pages


### PR DESCRIPTION
Adds the `threeparttable` package to have better table separators and adapt the example to follow common style guides.

## Before
<img width="800" alt="Bildschirmfoto 2024-06-07 um 21 33 13" src="https://github.com/anoma/art-template/assets/20623991/1e39eaa4-7e0f-4d44-ab74-6c5206ae508f">

## After
<img width="799" alt="Bildschirmfoto 2024-06-07 um 21 32 55" src="https://github.com/anoma/art-template/assets/20623991/38b076bd-69fd-4f1f-80e6-9249ee3de609">